### PR TITLE
Change Nuclear Science Pack recipe to require wood and steam, and other changes to accomodate this change

### DIFF
--- a/src/locale/en/locale.cfg
+++ b/src/locale/en/locale.cfg
@@ -1,8 +1,8 @@
 [mod-name]
-atan-nuclear-science=Nuclear Science
+atan-nuclear-science=Energy Science
 
 [mod-description]
-atan-nuclear-science=Adds nuclear science as Nauvis's science pack.
+atan-nuclear-science=Adds Energy science as Nauvis's science pack.
 
 [mod-setting-name]
 atan-nuclear-centrifuge-base-productivity=Enable [item=centrifuge] centrifuge base 50% productivity
@@ -14,10 +14,10 @@ atan-nuclear-centrifuge-base-productivity=When enabled, the [item=centrifuge] ce
 centrifuge=Critical for nuclear research and processes.
 
 [item-name]
-nuclear-science-pack=Nuclear science pack
+nuclear-science-pack=Energy science pack
 
 [technology-name]
-nuclear-science-pack=Nuclear science pack
+nuclear-science-pack=Energy science pack
 
 [technology-description]
 nuclear-science-pack=More advanced atomic physics applications.

--- a/src/prototypes/recipe.lua
+++ b/src/prototypes/recipe.lua
@@ -10,7 +10,8 @@ data:extend({
     {
         type = "recipe",
         name = "nuclear-science-pack",
-        category = "centrifuging",
+        --category = "centrifuging",
+        category = "crafting-with-fluid",
         surface_conditions = {
             {
                 property = "pressure",
@@ -21,14 +22,15 @@ data:extend({
         enabled = false,
         ingredients = {
             { type = "item", name = "uranium-235", amount = 1 },
-            { type = "item", name = "electronic-circuit", amount = 3 },
-            { type = "item", name = "solid-fuel", amount = 2 },
+            { type = "item", name = "wood", amount = 1},
+            { type = "fluid", name = "steam", amount = 500 },
         },
         energy_required = 10,
-        results = { { type = "item", name = "nuclear-science-pack", amount = 1 } },
+        results = { { type = "item", name = "nuclear-science-pack", amount = 3 } },
         allow_productivity = true,
     },
 })
+
 
 local uranium_recipes = {
     "atomic-bomb",
@@ -65,3 +67,11 @@ end
 if data.raw["recipe"]["uranium-fuel-cell"] then
     data.raw["recipe"]["uranium-fuel-cell"].category = "centrifuging"
 end
+
+data.raw["recipe"]["agricultural-tower"].ingredients = 
+{
+  {type = "item", name = "steel-plate", amount = 10},
+  {type = "item", name = "electronic-circuit", amount = 3},
+  --{type = "item", name = "spoilage", amount = 20},
+  {type = "item", name = "landfill", amount = 1}
+}

--- a/src/prototypes/recipe.lua
+++ b/src/prototypes/recipe.lua
@@ -21,12 +21,13 @@ data:extend({
         },
         enabled = false,
         ingredients = {
-            { type = "item", name = "uranium-235", amount = 1 },
+            --{ type = "item", name = "uranium-235", amount = 1 },
+            { type = "item", name = "uranium-238", amount = 1 },
             { type = "item", name = "wood", amount = 1},
             { type = "fluid", name = "steam", amount = 500 },
         },
         energy_required = 10,
-        results = { { type = "item", name = "nuclear-science-pack", amount = 3 } },
+        results = { { type = "item", name = "nuclear-science-pack", amount = 1 } },
         allow_productivity = true,
     },
 })

--- a/src/prototypes/technology.lua
+++ b/src/prototypes/technology.lua
@@ -137,3 +137,22 @@ delete_space_science_prereq_cost("atomic-bomb")
 if data.raw["technology"]["atomic-bomb"] and data.raw["technology"]["atomic-bomb"].unit then
     table.insert(data.raw["technology"]["atomic-bomb"].unit.ingredients, { "production-science-pack", 1 })
 end
+
+-- Changes to agriculture tower techs
+
+local tree_seeding=data.raw["technology"]["tree-seeding"]
+data.raw["technology"]["fish-breeding"].prerequisites=tree_seeding.prerequisites
+tree_seeding.unit.ingredients = {
+    { "automation-science-pack", 1 },
+    { "logistic-science-pack", 1 }
+}
+tree_seeding.prerequisites = {
+    "landfill"
+}
+table.insert(tree_seeding.effects,{type="unlock-recipe", recipe="agricultural-tower"})
+
+
+-- if mods["any-planet-start"] and settings.startup["aps-planet"].value ~= "nauvis" then
+
+-- end
+table.insert(data.raw["technology"]["nuclear-science-pack"].prerequisites,"tree-seeding")


### PR DESCRIPTION
This is an implementation of my recent suggestion to change the recipe of the science pack to require a more interesting setup.
To make wood harvesting possible on Nauvis, "Tree Seeding" has been moved earlier in the tech tree, and Agricultural towers, unlocked with Tree Seeding, no longer require spoilage.
https://mods.factorio.com/mod/atan-nuclear-science/discussion/674e28d33dd3b17ae6313b47

This change does three things:

1. Creates an additional step between solid fuel(or any other fuel) and science packs, by needing to burn it first. Also adds an opportunity to use steam from a nuclear power plant to reduce the fuel requirements of the science pack. Changing to beaconed/quality assemblers will require increasing the throughput of steam, making it increasingly challenging to scale up the factory, but the challenges can be resolved through clever design.
2. Increases the amount of land required on Nauvis to advance in the game, somewhat undoing Space Age's problem of factories being too small. While everything else gets smaller, the forest must grow.
3. Creates a late-game purpose for wood that can't be filled by anything else.

This has not been tested with "Any Planet Start."
The internal name of the Energy Science Pack is still "nuclear-science-pack," so if you want to change it, that is up to you.


This example setup for producing this science pack produces around 120 science per minute.
![image](https://github.com/user-attachments/assets/667da546-7c17-4bce-9cf3-5983f50b1c68)
![image](https://github.com/user-attachments/assets/1c14186c-102d-488a-aad6-daf49a72f0f3)
![image](https://github.com/user-attachments/assets/f3291294-d1ed-46b7-bacc-b6c581a3e517)


Changes nuclear science pack's name to "Energy Science Pack"

Changes Energy Science Pack recipe to require:

1 x Uranium-235
1 x wood
500 x steam
= 3x Energy Science Pack

Changed Energy Science pack to "crafting-with-fluid" type

Moved "Tree seeding" technology earlier in the tech tree, requiring only red and green science. Agricultural tower also unlock with this technology.

Removed spoilage from Agricultural tower recipe, making it craftable on Nauvis without going to Gleba.

Changed localization to refer to "Nuclear Science Pack" as "Energy Science Pack"